### PR TITLE
websocket url parsing made. In original version, device always tries to ...

### DIFF
--- a/devicehive/device/ws.py
+++ b/devicehive/device/ws.py
@@ -93,7 +93,7 @@ class WebSocketFactory(ClientFactory):
         self.devices = {}
     
     def buildProtocol(self, addr):
-        self.proto = WebSocketDeviceHiveProtocol(self, '/device')
+        self.proto = WebSocketDeviceHiveProtocol(self, 'device')
         if not IWebSocketMessanger.implementedBy(self.proto.__class__) :
             raise TypeError('Protocol has to implement IWebSocketMessanger interface.')
         return self.proto

--- a/devicehive/ws.py
+++ b/devicehive/ws.py
@@ -9,6 +9,7 @@ import json
 import base64
 import sha
 import struct
+import urlparse
 from time import time
 from random import Random
 from array import array
@@ -374,7 +375,8 @@ class WebSocketDeviceHiveProtocol(Protocol):
         @param timeout: timeout in seconds for requests
         """
         self.factory = factory
-        self.uri = uri
+        path = urlparse.urlparse(factory.url).path
+        self.uri = path + uri
         self.socket = None
         self.timeout = timeout
         # Each devicehive message has an accossiated response.


### PR DESCRIPTION
webSocketServerUrl url parsing made. In original version, python api always tries to connect

to websocket at http://websocketdomain/device, ignoring given path

For example:
{
  "apiVersion": "1.2.0",
  "serverTimestamp": "2014-07-06T07:25:01.820136",
  "webSocketServerUrl": "ws://domain.com:8080/DeviceHiveJava/websocket"
}
api tries to connect to websocket at "ws://domain.com:8080/device" and not to "ws://domain.com:8080/DeviceHiveJava/websocket/device"

After fix it connects to http://websocketdomain/websocketpath/device correctly.
